### PR TITLE
3.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
     - use emtable to read ctf refine results
     - create symlink if input mic is already mrc
     - refactor ctf refinement protocol to speed-up and clean-up
+    - fix the bug with removeBaseExt applied twice (reported by @EstrellaFG)
 3.0.16 - add possible outputs class, fix bug when refining input ctf
 3.0.15 - Remove tomo dependency
 3.0.14 - use weakImport for tomo

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.1 - refactor refinement protocol, add emtable requirement
 3.0.16 - add possible outputs class, fix bug when refining input ctf
 3.0.15 - Remove tomo dependency
 3.0.14 - use weakImport for tomo

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
-3.1 - refactor refinement protocol, add emtable requirement
+3.1:
+    - use emtable to read ctf refine results
+    - create symlink if input mic is already mrc
+    - refactor ctf refinement protocol to speed-up and clean-up
 3.0.16 - add possible outputs class, fix bug when refining input ctf
 3.0.15 - Remove tomo dependency
 3.0.14 - use weakImport for tomo

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ b) Developer's version
 
       scipion installp -p /path/to/scipion-em-gctf --devel
 
-Gctf binaries will be installed automatically with the plugin, but you can also link an existing installation. 
-Default installation path assumed is ``software/em/gctf-1.18``, if you want to change it, set *GCTF_HOME* in ``scipion.conf`` file to the folder where the Gctf is installed. Depending on your CUDA version and GPU card compute capability you might want to change the default binary from ``Gctf_v1.18_sm30-75_cu10.1`` to a different one by explicitly setting *GCTF* variable. If you need to use CUDA different from the one used during Scipion installation (defined by CUDA_LIB), you can add *GCTF_CUDA_LIB* variable to the config file. Various binaries can be downloaded from the official Gctf website.
+- Gctf binaries will be installed automatically with the plugin, but you can also link an existing installation. Default installation path assumed is ``software/em/gctf-1.18``, if you want to change it, set *GCTF_HOME* in ``scipion.conf`` file to the folder where the Gctf is installed. Depending on your CUDA version and GPU card compute capability you might want to change the default binary from ``Gctf_v1.18_sm30-75_cu10.1`` to a different one by explicitly setting *GCTF* variable.
+- If you need to use CUDA different from the one used during Scipion installation (defined by *CUDA_LIB*), you can add *GCTF_CUDA_LIB* variable to the config file. Various binaries can be downloaded from the official Gctf website.
 
 To check the installation, simply run one of the following Scipion tests: 
 
@@ -58,6 +58,7 @@ To check the installation, simply run one of the following Scipion tests:
 
    scipion test gctf.tests.test_protocols_gctf.TestGctfRefine
    scipion test gctf.tests.test_protocols_gctf.TestGctf
+   scipion tests gctf.tests.test_protocols_gctf_ts.TestGctfTs
 
 Supported versions
 ------------------

--- a/gctf/__init__.py
+++ b/gctf/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.0.16'
+__version__ = '3.1'
 _logo = "gctf_logo.png"
 _references = ['Zhang2016']
 

--- a/gctf/convert/convert.py
+++ b/gctf/convert/convert.py
@@ -124,8 +124,8 @@ _rlnCoordinateY #2
         self._f = open(filename, 'w')
         self._f.write(self.HEADER)
 
-    def writeCoord(self, x, y):
-        self._f.write("%d %d\n" % (x, y))
+    def writeCoord(self, pos):
+        self._f.write("%d %d\n" % (pos[0], pos[1]))
 
     def close(self):
         self._f.close()

--- a/gctf/protocols/protocol_gctf.py
+++ b/gctf/protocols/protocol_gctf.py
@@ -117,7 +117,7 @@ class ProtGctf(ProtCTFMicrographs):
             pwutils.cleanPath(micPath)
 
         except:
-            print("ERROR: Gctf has failed on %s/*.mrc" % micPath)
+            self.error("ERROR: Gctf has failed for %s/*.mrc" % micPath)
             import traceback
             traceback.print_exc()
 

--- a/gctf/protocols/protocol_gctf.py
+++ b/gctf/protocols/protocol_gctf.py
@@ -82,7 +82,10 @@ class ProtGctf(ProtCTFMicrographs):
                     sps = self._params['scannedPixelSize'] * downFactor
                     kwargs['scannedPixelSize'] = sps
                 else:
-                    ih.convert(micFn, micFnMrc, emlib.DT_FLOAT)
+                    if micFn.endswith('.mrc'):
+                        pwutils.createAbsLink(os.path.abspath(micFn), micFnMrc)
+                    else:
+                        ih.convert(micFn, micFnMrc, emlib.DT_FLOAT)
 
             program, args = self._gctfProgram.getCommand(**kwargs)
             args += ' %s/*.mrc' % micPath

--- a/gctf/protocols/protocol_gctf.py
+++ b/gctf/protocols/protocol_gctf.py
@@ -72,6 +72,11 @@ class ProtGctf(ProtCTFMicrographs):
             for mic in micList:
                 micFn = mic.getFileName()
                 # We convert the input micrograph on demand if not in .mrc
+
+                if not os.path.exists(micFn):
+                    self.error("Missing input micrograph: %s. Skipping..." % micFn)
+                    continue
+
                 downFactor = self.ctfDownFactor.get()
                 micFnMrc = os.path.join(micPath, pwutils.replaceBaseExt(micFn, 'mrc'))
 
@@ -96,6 +101,10 @@ class ProtGctf(ProtCTFMicrographs):
 
             for mic in micList:
                 micFn = mic.getFileName()
+
+                if not os.path.exists(micFn):
+                    continue
+
                 micBase = pwutils.removeBaseExt(micFn)
                 micFnMrc = _getFile(micBase, '.mrc')
                 # Let's clean the temporary mrc micrograph

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -368,8 +368,8 @@ class ProtGctfRefine(ProtParticles):
             if micId != lastMicId:  # Do no repeat check when this is the same mic
                 micFn = self.micDict.get(micName, None)
                 if micFn is None:
-                    print("Skipping all particles from a micrograph, "
-                          "key %s not found" % micName)
+                    self.warning("Skipping all particles from micrograph %s, "
+                                 "corresponding micrograph not found" % micName)
                 else:
                     newMicCallback(micFn)  # Notify about a new micrograph found
                 lastMicId = micId
@@ -385,7 +385,7 @@ class ProtGctfRefine(ProtParticles):
         scale = inputParts.getSamplingRate() / inputMics.getSamplingRate()
         doScale = abs(scale - 1.0 > 0.00001)
         if doScale:
-            print("Scaling coordinates by a factor *%0.2f*" % scale)
+            self.info("Scaling coordinates by a factor *%0.2f*" % scale)
 
         self._lastWriter = None
         coordDir = self._getTmpPath()
@@ -453,6 +453,9 @@ class ProtGctfRefine(ProtParticles):
                 self._args_refine += "--defV_err %f " % self.defVerr.get()
                 self._args_refine += "--defA_err %f " % self.defAerr.get()
                 self._args_refine += "--B_err %f " % self.Berr.get()
+            else:
+                self.warning("Skipping micrograph %s, CTF not found" % micKey)
+                return
 
         # Run Gctf refine
         try:
@@ -470,7 +473,7 @@ class ProtGctfRefine(ProtParticles):
             micFnCtfLocalOut = self._getCtfLocalOutPath(micFn)
             pwutils.moveFile(micFnCtfLocal, micFnCtfLocalOut)
         except:
-            print("ERROR: Gctf has failed on %s" % micFnMrc)
+            self.error("ERROR: Gctf has failed for %s" % micFnMrc)
             import traceback
             traceback.print_exc()
 

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -508,6 +508,10 @@ class ProtGctfRefine(ProtParticles):
         self._defineOutputs(**{outputs.outputParticles.name: partSet})
         self._defineTransformRelation(self.inputParticles, partSet)
 
+        if partSet.getSize() == 0:
+            raise Exception(pwutils.redStr("outputParticles has size zero, "
+                                           "please review processing steps above."))
+
     # -------------------------- INFO functions --------------------------------
     def _validate(self):
         errors = []

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -27,6 +27,7 @@
 import os
 from collections import OrderedDict
 from enum import Enum
+from emtable import Table
 
 import pyworkflow.utils as pwutils
 import pyworkflow.protocol.params as params
@@ -34,7 +35,6 @@ from pyworkflow.constants import PROD
 from pyworkflow.protocol.constants import STEPS_PARALLEL
 from pwem.constants import RELATION_CTF
 from pwem import emlib
-import pwem.emlib.metadata as md
 from pwem.protocols import EMProtocol, ProtParticles
 from pwem.objects import SetOfParticles
 
@@ -497,7 +497,7 @@ class ProtGctfRefine(ProtParticles):
             ctfFn = self._getCtfLocalOutPath(micBase)
             self._rowCounter = 0
             if os.path.exists(ctfFn):
-                self._rowList = [row.clone() for row in md.iterRows(ctfFn)]
+                self._rowList = Table(fileName=ctfFn, tableName='')
             else:
                 self._rowList = None
 

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -435,28 +435,24 @@ class ProtGctfRefine(ProtParticles):
         if self.useInputCtf and self.ctfRelations.hasValue():
             ctfs = self._getCtfs()
 
-            for ctf in ctfs.iterItems():
-                mic = ctf.getMicrograph()
-                ctfMicName = mic.getMicName()
-                ctfMicId = mic.getObjId()
-                if micKey == ctfMicName or micKey == ctfMicId:
-                    # add CTF refine options
-                    self._params.update({'refine_input_ctf': 1,
-                                         'defU_init': ctf.getDefocusU(),
-                                         'defV_init': ctf.getDefocusV(),
-                                         'defA_init': ctf.getDefocusAngle(),
-                                         'B_init': self.bfactor.get()
-                                         })
-                    self._args_refine += "--refine_input_ctf %d " % self._params['refine_input_ctf']
-                    self._args_refine += "--defU_init %f " % self._params['defU_init']
-                    self._args_refine += "--defV_init %f " % self._params['defV_init']
-                    self._args_refine += "--defA_init %f " % self._params['defA_init']
-                    self._args_refine += "--B_init %f " % self._params['B_init']
-                    self._args_refine += "--defU_err %f " % self.defUerr.get()
-                    self._args_refine += "--defV_err %f " % self.defVerr.get()
-                    self._args_refine += "--defA_err %f " % self.defAerr.get()
-                    self._args_refine += "--B_err %f " % self.Berr.get()
-                    break
+            ctf = ctfs.iterItems(where="_micObj._micName=='%s'" % micKey, iterate=False)
+            if ctf:
+                # add CTF refine options
+                self._params.update({'refine_input_ctf': 1,
+                                     'defU_init': ctf[0].getDefocusU(),
+                                     'defV_init': ctf[0].getDefocusV(),
+                                     'defA_init': ctf[0].getDefocusAngle(),
+                                     'B_init': self.bfactor.get()
+                                     })
+                self._args_refine += "--refine_input_ctf %d " % self._params['refine_input_ctf']
+                self._args_refine += "--defU_init %f " % self._params['defU_init']
+                self._args_refine += "--defV_init %f " % self._params['defV_init']
+                self._args_refine += "--defA_init %f " % self._params['defA_init']
+                self._args_refine += "--B_init %f " % self._params['B_init']
+                self._args_refine += "--defU_err %f " % self.defUerr.get()
+                self._args_refine += "--defV_err %f " % self.defVerr.get()
+                self._args_refine += "--defA_err %f " % self.defAerr.get()
+                self._args_refine += "--B_err %f " % self.Berr.get()
 
         # Run Gctf refine
         try:

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -515,6 +515,10 @@ class ProtGctfRefine(ProtParticles):
         if self.useInputCtf and not self._getCtfs:
             errors.append("Please provide input CTFs for refinement.")
 
+        if self.applyShift and not self.inputParticles.get().hasAlignment():
+            errors.append("Input particles do not have alignment info, "
+                          "cannot apply shifts")
+
         return errors
 
     def _summary(self):

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -414,6 +414,10 @@ class ProtGctfRefine(ProtParticles):
         micPath = self._getTmpPath(pwutils.removeBaseExt(micFn))
         # We convert the input micrograph on demand if not in .mrc
 
+        if not os.path.exists(micFn):
+            self.error("Missing input micrograph: %s. Skipping..." % micFn)
+            return
+
         downFactor = self.ctfDownFactor.get()
         ih = emlib.image.ImageHandler()
         micFnMrc = os.path.join(micPath, pwutils.replaceBaseExt(micFn, 'mrc'))
@@ -485,8 +489,7 @@ class ProtGctfRefine(ProtParticles):
         self._rowCounter = 0
 
         def _newMic(micFn):
-            micBase = pwutils.removeBaseExt(micFn)
-            ctfFn = self._getCtfLocalOutPath(micBase)
+            ctfFn = self._getCtfLocalOutPath(micFn)
             self._rowCounter = 0
             if os.path.exists(ctfFn):
                 self._rowList = Table(fileName=ctfFn, tableName='')
@@ -515,7 +518,7 @@ class ProtGctfRefine(ProtParticles):
         if self.useInputCtf and not self._getCtfs:
             errors.append("Please provide input CTFs for refinement.")
 
-        if self.applyShift and not self.inputParticles.get().hasAlignment():
+        if self.applyShifts and not self.inputParticles.get().hasAlignment():
             errors.append("Input particles do not have alignment info, "
                           "cannot apply shifts")
 

--- a/gctf/protocols/protocol_gctf_refine.py
+++ b/gctf/protocols/protocol_gctf_refine.py
@@ -466,19 +466,8 @@ class ProtGctfRefine(ProtParticles):
             pwutils.cleanPath(micFnMrc)
     
             # move output from tmp to extra
-            micFnCtf = os.path.join(micPath, pwutils.replaceBaseExt(micFn, 'ctf'))
-            micFnCtfLog = os.path.join(micPath, pwutils.removeBaseExt(micFn) + '_gctf.log')
-            micFnCtfFit = os.path.join(micPath, pwutils.removeBaseExt(micFn) + '_EPA.log')
             micFnCtfLocal = os.path.join(micPath, pwutils.removeBaseExt(micFn) + '_local.star')
-    
-            micFnCtfOut = self._getPsdPath(micFn)
-            micFnCtfLogOut = self._getCtfOutPath(micFn)
-            micFnCtfFitOut = self._getCtfFitOutPath(micFn)
             micFnCtfLocalOut = self._getCtfLocalOutPath(micFn)
-    
-            pwutils.moveFile(micFnCtf, micFnCtfOut)
-            pwutils.moveFile(micFnCtfLog, micFnCtfLogOut)
-            pwutils.moveFile(micFnCtfFit, micFnCtfFitOut)
             pwutils.moveFile(micFnCtfLocal, micFnCtfLocalOut)
         except:
             print("ERROR: Gctf has failed on %s" % micFnMrc)

--- a/gctf/protocols/protocol_ts_gctf.py
+++ b/gctf/protocols/protocol_ts_gctf.py
@@ -88,7 +88,6 @@ class ProtTsGctf(ProtTsEstimateCTF):
             micBase = pwutils.removeBaseExt(tiFn)
 
             def _getFile(suffix):
-                print("File: %s" % os.path.join(workingDir, micBase + suffix))
                 return os.path.join(workingDir, micBase + suffix)
 
             # move output from tmp to extra
@@ -99,7 +98,7 @@ class ProtTsGctf(ProtTsEstimateCTF):
                              self._getExtraPath())
 
         except Exception as ex:
-            print("ERROR: Gctf has failed for %s" % tiFn)
+            self.error("ERROR: Gctf has failed for %s" % tiFn)
 
     # --------------------------- INFO functions ------------------------------
     def _validate(self):

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['scipion-em'],  # Optional
+    install_requires=['scipion-em', 'emtable'],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"


### PR DESCRIPTION
3.1:
    - use emtable to read ctf refine results
    - create symlink if input mic is already mrc
    - refactor ctf refinement protocol to speed-up and clean-up
    - fix the bug with removeBaseExt applied twice (reported by @EstrellaFG)